### PR TITLE
✏️ correct last `PARTICIPATION_FLAG_WEIGHTS` by `TIMELY_HEAD_WEIGHT`

### DIFF
--- a/altair/beacon-chain.md
+++ b/altair/beacon-chain.md
@@ -156,7 +156,7 @@ If you are offline with probability `q`, then your rewards are `B * [(50/64 * p 
 | Name | Value |
 | - | - |
 | `G2_POINT_AT_INFINITY` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
-| `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_FLAG_INDEX]` |
+| `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]` |
 
 ## Configuration
 


### PR DESCRIPTION
Hi team,

I guess in `PARTICIPATION_FLAG_WEIGHTS`, the last element of the array is `TIMELY_HEAD_WEIGHT` and not `TIMELY_HEAD_FLAG_INDEX`.

Don't hesitate to correct me if I'm wrong.